### PR TITLE
Chapter 4/typing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,12 +1,14 @@
 [flake8]
+; ANN - Issues raised by flake8-annotations
+; B - Issues raised by flake8-bugbear, B9 are more opinionated
 ; BLK - Issues raised by Black
 ; C - Issues rasied by mccabe (complexity)
 ; F - Errors raised by pyflakes
-; W,E - Warnings and Errors reported by pycodestyle
 ; I - Issues raised by flake8-import-order
-; B - Issues raised by flake8-bugbear, B9 are more opinionated
 ; S - Issues raised by flake8-bandit (security)
-select = B,B9,BLK,C,E,F,I,S,W
+; W,E - Warnings and Errors reported by pycodestyle
+select = ANN,B,B9,BLK,C,E,F,I,S,W
+
 
 ; E203 - Whitespace before ':'
 ; W503 - Line break before binary operator

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+
+[mypy-nox.*,pytest]
+ignore_missing_imports = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,17 +1,29 @@
 # https://nox.thea.codes/en/stable/config.html#modifying-nox-s-behavior-in-the-noxfile
 import nox
 
-nox.options.sessions = "lint", "tests"
+nox.options.sessions = "lint", "mypy", "tests"
 
 
 PYTHON_VERSIONS = ["3.12", "3.11", "3.10", "3.9", "3.8"]
-LINT_TARGETS = ["src/", "tests/", "./noxfile.py"]
+SOURCE_CODE_TARGETS = ["src/", "tests/", "./noxfile.py"]
+
+
+@nox.session(python="3.11")
+def mypy(session):
+    args = session.posargs or SOURCE_CODE_TARGETS
+    session.install("mypy")
+
+    # XXX: Doing this to workaround the install_with_constraints issue.
+    session.run("poetry", "install", external=True)
+    session.install("types-requests")
+
+    session.run("mypy", *args)
 
 
 # TODO: Do I need to keep this if I am using flake8-black?
 @nox.session(python="3.11")
 def black(session):
-    args = session.posargs or LINT_TARGETS
+    args = session.posargs or SOURCE_CODE_TARGETS
     session.install("black")
     session.run("black", *args)
 
@@ -23,7 +35,7 @@ def black(session):
 # @nox.session(python=PYTHON_VERSIONS)
 @nox.session(python="3.11")
 def lint(session):
-    args = session.posargs or LINT_TARGETS
+    args = session.posargs or SOURCE_CODE_TARGETS
     session.install(
         "flake8",
         "flake8-bandit",

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,6 +56,7 @@ def lint(session: Session) -> None:
     args = session.posargs or SOURCE_CODE_TARGETS
     session.install(
         "flake8",
+        "flake8-annotations",
         "flake8-bandit",
         "flake8-black",
         "flake8-bugbear",

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,9 @@ def mypy(session):
 
 
 # TODO: Do I need to keep this if I am using flake8-black?
+# A: Maybe.  When flake8-black runs it may report an issue without enough detail to fix it.  In that
+#    case, I've been running `nox -s black` to resolve the issue.  However, there seems to be a
+#    difference in the configuration of the two.  I haven't looked into that yet.
 @nox.session(python="3.11")
 def black(session):
     args = session.posargs or SOURCE_CODE_TARGETS

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ def mypy(session):
     session.install("mypy")
 
     # XXX: Doing this to workaround the install_with_constraints issue.
-    session.run("poetry", "install", external=True)
+    session.run("poetry", "install", "--no-root", external=True)
     session.install("types-requests")
 
     session.run("mypy", *args)

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,6 +15,15 @@ SOURCE_CODE_TARGETS = ["src/", "tests/", "./noxfile.py"]
 
 
 @nox.session(python="3.11")
+def typeguard(session: Session) -> None:
+    args = session.posargs or ["-m", "not e2e"]
+    session.run("poetry", "install", "--no-dev", external=True)
+
+    session.install("pytest", "pytest-mock", "typeguard")
+    session.run("pytest", "--typeguard-packages=hypermodern_python", *args)
+
+
+@nox.session(python="3.11")
 def mypy(session: Session) -> None:
     args = session.posargs or SOURCE_CODE_TARGETS
     session.install("mypy")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 # https://nox.thea.codes/en/stable/config.html#modifying-nox-s-behavior-in-the-noxfile
 import nox
+from nox.sessions import Session
 
 nox.options.sessions = "lint", "mypy", "tests"
 
@@ -8,8 +9,13 @@ PYTHON_VERSIONS = ["3.12", "3.11", "3.10", "3.9", "3.8"]
 SOURCE_CODE_TARGETS = ["src/", "tests/", "./noxfile.py"]
 
 
+# TODO: Return to reimplement this.  For now, just make note the signature.
+# def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> None:
+#     pass
+
+
 @nox.session(python="3.11")
-def mypy(session):
+def mypy(session: Session) -> None:
     args = session.posargs or SOURCE_CODE_TARGETS
     session.install("mypy")
 
@@ -25,7 +31,7 @@ def mypy(session):
 #    case, I've been running `nox -s black` to resolve the issue.  However, there seems to be a
 #    difference in the configuration of the two.  I haven't looked into that yet.
 @nox.session(python="3.11")
-def black(session):
+def black(session: Session) -> None:
     args = session.posargs or SOURCE_CODE_TARGETS
     session.install("black")
     session.run("black", *args)
@@ -37,7 +43,7 @@ def black(session):
 # - Can I dynamically select the python version being used by the dev and just use that instead of hardcode?
 # @nox.session(python=PYTHON_VERSIONS)
 @nox.session(python="3.11")
-def lint(session):
+def lint(session: Session) -> None:
     args = session.posargs or SOURCE_CODE_TARGETS
     session.install(
         "flake8",
@@ -50,7 +56,7 @@ def lint(session):
 
 
 @nox.session(python=PYTHON_VERSIONS)
-def tests(session):
+def tests(session: Session) -> None:
     args = session.posargs or ["--cov", "-m", "not e2e"]
     session.run("poetry", "install", external=True)
     session.run("pytest", *args)

--- a/poetry.lock
+++ b/poetry.lock
@@ -427,6 +427,64 @@ files = [
 traitlets = "*"
 
 [[package]]
+name = "mypy"
+version = "1.10.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:da1cbf08fb3b851ab3b9523a884c232774008267b1f83371ace57f412fe308c2"},
+    {file = "mypy-1.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:12b6bfc1b1a66095ab413160a6e520e1dc076a28f3e22f7fb25ba3b000b4ef99"},
+    {file = "mypy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e36fb078cce9904c7989b9693e41cb9711e0600139ce3970c6ef814b6ebc2b2"},
+    {file = "mypy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b0695d605ddcd3eb2f736cd8b4e388288c21e7de85001e9f85df9187f2b50f9"},
+    {file = "mypy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:cd777b780312ddb135bceb9bc8722a73ec95e042f911cc279e2ec3c667076051"},
+    {file = "mypy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3be66771aa5c97602f382230165b856c231d1277c511c9a8dd058be4784472e1"},
+    {file = "mypy-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8b2cbaca148d0754a54d44121b5825ae71868c7592a53b7292eeb0f3fdae95ee"},
+    {file = "mypy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ec404a7cbe9fc0e92cb0e67f55ce0c025014e26d33e54d9e506a0f2d07fe5de"},
+    {file = "mypy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e22e1527dc3d4aa94311d246b59e47f6455b8729f4968765ac1eacf9a4760bc7"},
+    {file = "mypy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:a87dbfa85971e8d59c9cc1fcf534efe664d8949e4c0b6b44e8ca548e746a8d53"},
+    {file = "mypy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a781f6ad4bab20eef8b65174a57e5203f4be627b46291f4589879bf4e257b97b"},
+    {file = "mypy-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b808e12113505b97d9023b0b5e0c0705a90571c6feefc6f215c1df9381256e30"},
+    {file = "mypy-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f55583b12156c399dce2df7d16f8a5095291354f1e839c252ec6c0611e86e2e"},
+    {file = "mypy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4cf18f9d0efa1b16478c4c129eabec36148032575391095f73cae2e722fcf9d5"},
+    {file = "mypy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:bc6ac273b23c6b82da3bb25f4136c4fd42665f17f2cd850771cb600bdd2ebeda"},
+    {file = "mypy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9fd50226364cd2737351c79807775136b0abe084433b55b2e29181a4c3c878c0"},
+    {file = "mypy-1.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f90cff89eea89273727d8783fef5d4a934be2fdca11b47def50cf5d311aff727"},
+    {file = "mypy-1.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcfc70599efde5c67862a07a1aaf50e55bce629ace26bb19dc17cece5dd31ca4"},
+    {file = "mypy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:075cbf81f3e134eadaf247de187bd604748171d6b79736fa9b6c9685b4083061"},
+    {file = "mypy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:3f298531bca95ff615b6e9f2fc0333aae27fa48052903a0ac90215021cdcfa4f"},
+    {file = "mypy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa7ef5244615a2523b56c034becde4e9e3f9b034854c93639adb667ec9ec2976"},
+    {file = "mypy-1.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3236a4c8f535a0631f85f5fcdffba71c7feeef76a6002fcba7c1a8e57c8be1ec"},
+    {file = "mypy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2b5cdbb5dd35aa08ea9114436e0d79aceb2f38e32c21684dcf8e24e1e92821"},
+    {file = "mypy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92f93b21c0fe73dc00abf91022234c79d793318b8a96faac147cd579c1671746"},
+    {file = "mypy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:28d0e038361b45f099cc086d9dd99c15ff14d0188f44ac883010e172ce86c38a"},
+    {file = "mypy-1.10.0-py3-none-any.whl", hash = "sha256:f8c083976eb530019175aabadb60921e73b4f45736760826aa1689dda8208aee"},
+    {file = "mypy-1.10.0.tar.gz", hash = "sha256:3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 description = "Core utilities for Python packages"
@@ -736,4 +794,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "828ede6da4c6f87cdfb21c6fe2a10ef40e925c2ea9796e06475249d0088d2e60"
+content-hash = "009061e27689fcfdad1cb81dfc089d8a95bdc689bb6dd97624fa57d819fe59c1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -321,6 +321,37 @@ files = [
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
 
 [[package]]
+name = "flake8"
+version = "7.1.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8-7.1.0-py2.py3-none-any.whl", hash = "sha256:2e416edcc62471a64cea09353f4e7bdba32aeb079b6e360554c659a122b1bc6a"},
+    {file = "flake8-7.1.0.tar.gz", hash = "sha256:48a07b626b55236e0fb4784ee69a465fbf59d79eec1f5b4785c3d3bc57d17aa5"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.12.0,<2.13.0"
+pyflakes = ">=3.2.0,<3.3.0"
+
+[[package]]
+name = "flake8-annotations"
+version = "3.1.1"
+description = "Flake8 Type Annotation Checks"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8_annotations-3.1.1-py3-none-any.whl", hash = "sha256:102935bdcbfa714759a152aeb07b14aee343fc0b6f7c55ad16968ce3e0e91a8a"},
+    {file = "flake8_annotations-3.1.1.tar.gz", hash = "sha256:6c98968ccc6bdc0581d363bf147a87df2f01d0d078264b2da805799d911cf5fe"},
+]
+
+[package.dependencies]
+attrs = ">=21.4"
+flake8 = ">=5.0"
+
+[[package]]
 name = "idna"
 version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -504,6 +535,17 @@ files = [
 traitlets = "*"
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
 name = "mypy"
 version = "1.10.0"
 description = "Optional static typing for Python"
@@ -665,6 +707,28 @@ files = [
 
 [package.extras]
 tests = ["pytest"]
+
+[[package]]
+name = "pycodestyle"
+version = "2.12.0"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycodestyle-2.12.0-py2.py3-none-any.whl", hash = "sha256:949a39f6b86c3e1515ba1787c2022131d165a8ad271b11370a8819aa070269e4"},
+    {file = "pycodestyle-2.12.0.tar.gz", hash = "sha256:442f950141b4f43df752dd303511ffded3a04c2b6fb7f65980574f0c31e6e79c"},
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.2.0"
+description = "passive checker of Python programs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
+    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
+]
 
 [[package]]
 name = "pygments"
@@ -919,5 +983,5 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<3.13"
-content-hash = "e7e4f0560077229f4d300a08592c450b0944fa59c0a6efca461df566abef7d19"
+python-versions = ">=3.8.1,<3.13"
+content-hash = "7b5275a21018f4b753c382b24e5b61d4cbe1523a37051b6d89ae9ce3c8980986"

--- a/poetry.lock
+++ b/poetry.lock
@@ -332,6 +332,25 @@ files = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.0.0"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f"},
+    {file = "importlib_metadata-8.0.0.tar.gz", hash = "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"},
+]
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -811,6 +830,25 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
+name = "typeguard"
+version = "4.3.0"
+description = "Run-time type checker for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "typeguard-4.3.0-py3-none-any.whl", hash = "sha256:4d24c5b39a117f8a895b9da7a9b3114f04eb63bade45a4492de49b175b6f7dfa"},
+    {file = "typeguard-4.3.0.tar.gz", hash = "sha256:92ee6a0aec9135181eae6067ebd617fd9de8d75d714fb548728a4933b1dea651"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
+typing-extensions = ">=4.10.0"
+
+[package.extras]
+doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.3.0)"]
+test = ["coverage[toml] (>=7)", "mypy (>=1.2.0)", "pytest (>=7)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -864,7 +902,22 @@ files = [
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
 
+[[package]]
+name = "zipp"
+version = "3.19.2"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
+    {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
+]
+
+[package.extras]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "09467e5e34f744ae76d03a34e15a50eebf3179710243b180c0158236385ba49a"
+content-hash = "e7e4f0560077229f4d300a08592c450b0944fa59c0a6efca461df566abef7d19"

--- a/poetry.lock
+++ b/poetry.lock
@@ -30,6 +30,25 @@ astroid = ["astroid (>=1,<2)", "astroid (>=2,<4)"]
 test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
 
 [[package]]
+name = "attrs"
+version = "23.2.0"
+description = "Classes Without Boilerplate"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
+    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
+]
+
+[package.extras]
+cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
+dev = ["attrs[tests]", "pre-commit"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
+tests = ["attrs[tests-no-zope]", "zope-interface"]
+tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
+tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
+
+[[package]]
 name = "backcall"
 version = "0.2.0"
 description = "Specifications for callback functions passed in to an API"
@@ -254,6 +273,26 @@ files = [
 ]
 
 [[package]]
+name = "desert"
+version = "2022.9.22"
+description = "Deserialize to objects while staying DRY"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "desert-2022.9.22-py3-none-any.whl", hash = "sha256:cad7b6f1936448d26bde403882ec6855786b4d24d38d0ed4400e505ac8c5591f"},
+    {file = "desert-2022.9.22.tar.gz", hash = "sha256:0f45e098915e16452a269a1da0bcbbf31df0af2173899f1c097fb2e3b0265d89"},
+]
+
+[package.dependencies]
+attrs = "*"
+marshmallow = ">=3.0"
+typing-inspect = "*"
+
+[package.extras]
+dev = ["black", "build", "bump2version", "check-manifest", "coverage", "cuvner", "docutils", "importlib-metadata", "isort", "marshmallow-enum", "marshmallow-union", "mypy", "pex", "pygments", "pylint", "pytest", "pytest-cov", "pytest-sphinx", "pytest-travis-fold", "readme-renderer", "towncrier", "tox", "twine", "versioneer", "wheel"]
+test = ["coverage", "cuvner", "importlib-metadata", "marshmallow-enum", "marshmallow-union", "pytest", "pytest-cov", "pytest-sphinx", "pytest-travis-fold", "tox"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -411,6 +450,25 @@ parso = ">=0.8.3,<0.9.0"
 docs = ["Jinja2 (==2.11.3)", "MarkupSafe (==1.1.1)", "Pygments (==2.8.1)", "alabaster (==0.7.12)", "babel (==2.9.1)", "chardet (==4.0.0)", "commonmark (==0.8.1)", "docutils (==0.17.1)", "future (==0.18.2)", "idna (==2.10)", "imagesize (==1.2.0)", "mock (==1.0.1)", "packaging (==20.9)", "pyparsing (==2.4.7)", "pytz (==2021.1)", "readthedocs-sphinx-ext (==2.1.4)", "recommonmark (==0.5.0)", "requests (==2.25.1)", "six (==1.15.0)", "snowballstemmer (==2.1.0)", "sphinx (==1.8.5)", "sphinx-rtd-theme (==0.4.3)", "sphinxcontrib-serializinghtml (==1.1.4)", "sphinxcontrib-websupport (==1.2.4)", "urllib3 (==1.26.4)"]
 qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
 testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
+
+[[package]]
+name = "marshmallow"
+version = "3.21.3"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "marshmallow-3.21.3-py3-none-any.whl", hash = "sha256:86ce7fb914aa865001a4b2092c4c2872d13bc347f3d42673272cabfdbad386f1"},
+    {file = "marshmallow-3.21.3.tar.gz", hash = "sha256:4f57c5e050a54d66361e826f94fba213eb10b67b2fdb02c3e0343ce207ba1662"},
+]
+
+[package.dependencies]
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
+docs = ["alabaster (==0.7.16)", "autodocsumm (==0.2.12)", "sphinx (==7.3.7)", "sphinx-issues (==4.1.0)", "sphinx-version-warning (==1.1.2)"]
+tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
 name = "matplotlib-inline"
@@ -764,6 +822,21 @@ files = [
 ]
 
 [[package]]
+name = "typing-inspect"
+version = "0.9.0"
+description = "Runtime inspection utilities for typing module."
+optional = false
+python-versions = "*"
+files = [
+    {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
+    {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -794,4 +867,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "009061e27689fcfdad1cb81dfc089d8a95bdc689bb6dd97624fa57d819fe59c1"
+content-hash = "09467e5e34f744ae76d03a34e15a50eebf3179710243b180c0158236385ba49a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ keywords = ["hypermodern", "template", "package"]
 python = ">=3.8,<3.13"
 click = "^8.1.7"
 requests = "^2.32.3"
+desert = "^2022.9.22"
+marshmallow = "^3.21.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ ipdb = "^0.13.13"
 # ======================================================================
 # CLI Entrypoints
 # ======================================================================
+mypy = "^1.10.0"
 [tool.poetry.scripts]
 hypermodern-python = "hypermodern_python.console:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ ipdb = "^0.13.13"
 # CLI Entrypoints
 # ======================================================================
 mypy = "^1.10.0"
+typeguard = "^4.3.0"
 [tool.poetry.scripts]
 hypermodern-python = "hypermodern_python.console:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = ["hypermodern", "template", "package"]
 
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.13"
+python = ">=3.8.1,<3.13"
 click = "^8.1.7"
 requests = "^2.32.3"
 desert = "^2022.9.22"
@@ -43,6 +43,7 @@ ipdb = "^0.13.13"
 # ======================================================================
 mypy = "^1.10.0"
 typeguard = "^4.3.0"
+flake8-annotations = "^3.1.1"
 [tool.poetry.scripts]
 hypermodern-python = "hypermodern_python.console:main"
 

--- a/src/hypermodern_python/console.py
+++ b/src/hypermodern_python/console.py
@@ -23,10 +23,7 @@ from . import __version__, wikipedia
 @click.version_option(version=__version__)
 def main(language: str) -> None:
     """The Hypermodern Python Project"""
-    data = wikipedia.random_page(language=language)
+    page = wikipedia.random_page(language=language)
 
-    title = data["title"]
-    extract = data["extract"]
-
-    click.secho(title, fg="green")
-    click.echo(textwrap.fill(extract))
+    click.secho(page.title, fg="green")
+    click.echo(textwrap.fill(page.extract))

--- a/src/hypermodern_python/console.py
+++ b/src/hypermodern_python/console.py
@@ -5,6 +5,12 @@ import click
 from . import __version__, wikipedia
 
 
+# !!! LEFT OFF HERE !!!
+#   https://cjolowicz.github.io/posts/hypermodern-python-04-typing/
+# I may need to address Issue #4 (the install_with_constraints issue) before I can move
+# forward.  Alternatively, I could start ignoring things like `click` temporarily and
+# come back to fix them later.  Or I could install the whole poetry environment before
+# running mypy.
 @click.command()
 @click.option(
     "--language",
@@ -15,7 +21,7 @@ from . import __version__, wikipedia
     show_default=True,
 )
 @click.version_option(version=__version__)
-def main(language):
+def main(language: str) -> None:
     """The Hypermodern Python Project"""
     data = wikipedia.random_page(language=language)
 

--- a/src/hypermodern_python/wikipedia.py
+++ b/src/hypermodern_python/wikipedia.py
@@ -30,6 +30,6 @@ def random_page(language: str = "en") -> Page:
             response.raise_for_status()
             data = response.json()
             return schema.load(data)
-    except requests.RequestException as error:
+    except (requests.RequestException, marshmallow.ValidationError) as error:
         message = str(error)
         raise click.ClickException(message) from error

--- a/src/hypermodern_python/wikipedia.py
+++ b/src/hypermodern_python/wikipedia.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any
 
 import click
@@ -7,11 +8,17 @@ import requests
 API_URL: str = "https://{language}.wikipedia.org/api/rest_v1/page/random/summary"
 
 
+@dataclass
+class Page:
+    title: str
+    extract: str
+
+
 def get_api_url_for(language: str) -> str:
     return API_URL.format(language=language)
 
 
-def random_page(language: str = "en") -> Any:
+def random_page(language: str = "en") -> Page:
     url = get_api_url_for(language=language)
     try:
         with requests.get(url, timeout=10) as response:

--- a/src/hypermodern_python/wikipedia.py
+++ b/src/hypermodern_python/wikipedia.py
@@ -1,15 +1,17 @@
+from typing import Any
+
 import click
 import requests
 
 
-API_URL = "https://{language}.wikipedia.org/api/rest_v1/page/random/summary"
+API_URL: str = "https://{language}.wikipedia.org/api/rest_v1/page/random/summary"
 
 
-def get_api_url_for(language):
+def get_api_url_for(language: str) -> str:
     return API_URL.format(language=language)
 
 
-def random_page(language="en"):
+def random_page(language: str = "en") -> Any:
     url = get_api_url_for(language=language)
     try:
         with requests.get(url, timeout=10) as response:

--- a/src/hypermodern_python/wikipedia.py
+++ b/src/hypermodern_python/wikipedia.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Any
 
 import click
 import desert

--- a/src/hypermodern_python/wikipedia.py
+++ b/src/hypermodern_python/wikipedia.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import click
+import desert
+import marshmallow
 import requests
 
 
@@ -14,6 +16,9 @@ class Page:
     extract: str
 
 
+schema = desert.schema(Page, meta={"unknown": marshmallow.EXCLUDE})
+
+
 def get_api_url_for(language: str) -> str:
     return API_URL.format(language=language)
 
@@ -23,7 +28,8 @@ def random_page(language: str = "en") -> Page:
     try:
         with requests.get(url, timeout=10) as response:
             response.raise_for_status()
-            return response.json()
+            data = response.json()
+            return schema.load(data)
     except requests.RequestException as error:
         message = str(error)
         raise click.ClickException(message) from error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+from unittest.mock import Mock
+
 import pytest
+from pytest_mock import MockerFixture
 
 
 def pytest_configure(config):
@@ -6,7 +9,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def mock_requests_get(mocker):
+def mock_requests_get(mocker: MockerFixture) -> Mock:
     mock = mocker.patch("requests.get")
     mock.return_value.__enter__.return_value.json.return_value = {
         "title": "Guy Hoozdis",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "e2e: mark as end-to-end test.")
 
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -33,14 +33,18 @@ def test_main_prints_title(runner: CliRunner) -> None:
 
 
 # TODO: This is an integration test, not a unit test.
-def test_main_prints_message_on_request_error(runner: CliRunner, mock_requests_get: Mock) -> None:
+def test_main_prints_message_on_request_error(
+    runner: CliRunner, mock_requests_get: Mock
+) -> None:
     mock_requests_get.side_effect = requests.RequestException
     result = runner.invoke(console.main)
     assert "Error" in result.output
 
 
 # TODO: This is an integration test, not a unit test.
-def test_main_uses_specified_language(runner: CliRunner, mock_wikipedia_random_page: Mock) -> None:
+def test_main_uses_specified_language(
+    runner: CliRunner, mock_wikipedia_random_page: Mock
+) -> None:
     language = "pl"
     runner.invoke(console.main, [f"--language={language}"])
     mock_wikipedia_random_page.assert_called_once_with(language=language)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -27,7 +27,7 @@ def test_main_succeeds(runner: CliRunner) -> None:
 
 
 # TODO: This is an integration test, not a unit test.
-def test_main_prints_title(runner: CliRunner) -> None:
+def test_main_prints_title(runner: CliRunner, mock_requests_get: Mock) -> None:
     result = runner.invoke(console.main)
     assert "Guy Hoozdis" in result.output
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,47 +1,50 @@
-import click.testing
+from unittest.mock import Mock
+
 import pytest
 import requests
+from click.testing import CliRunner
+from pytest_mock import MockerFixture
 
 from hypermodern_python import console
 
 
 @pytest.fixture
-def runner():
-    return click.testing.CliRunner()
+def runner() -> CliRunner:
+    return CliRunner()
 
 
 @pytest.fixture
-def mock_wikipedia_random_page(mocker):
+def mock_wikipedia_random_page(mocker: MockerFixture) -> Mock:
     return mocker.patch("hypermodern_python.wikipedia.random_page")
 
 
 # TODO: This is an integration test, not a unit test.
-def test_main_succeeds(runner, mock_requests_get):
+def test_main_succeeds(runner: CliRunner) -> None:
     result = runner.invoke(console.main)
     assert result.exit_code == 0
 
 
 # TODO: This is an integration test, not a unit test.
-def test_main_prints_title(runner, mock_requests_get):
+def test_main_prints_title(runner: CliRunner) -> None:
     result = runner.invoke(console.main)
     assert "Guy Hoozdis" in result.output
 
 
 # TODO: This is an integration test, not a unit test.
-def test_main_prints_message_on_request_error(runner, mock_requests_get):
+def test_main_prints_message_on_request_error(runner: CliRunner, mock_requests_get: Mock) -> None:
     mock_requests_get.side_effect = requests.RequestException
     result = runner.invoke(console.main)
     assert "Error" in result.output
 
 
 # TODO: This is an integration test, not a unit test.
-def test_main_uses_specified_language(runner, mock_wikipedia_random_page):
+def test_main_uses_specified_language(runner: CliRunner, mock_wikipedia_random_page: Mock) -> None:
     language = "pl"
     runner.invoke(console.main, [f"--language={language}"])
     mock_wikipedia_random_page.assert_called_once_with(language=language)
 
 
 @pytest.mark.e2e
-def test_main_succeeds_in_production_env(runner):
+def test_main_succeeds_in_production_env(runner: CliRunner) -> None:
     result = runner.invoke(console.main)
     assert result.exit_code == 0

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,9 +1,11 @@
 from unittest.mock import Mock
 
-import pytest
-import requests
+# TODO: The configurations for black and flake8-black are inconsistent.  Also, I hate this choice
+# for import ordering.  Fix it.
 from click.testing import CliRunner
+import pytest
 from pytest_mock import MockerFixture
+import requests
 
 from hypermodern_python import console
 

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -7,7 +7,9 @@ import requests
 from hypermodern_python import wikipedia
 
 
-def test_random_page_raises_click_exception_on_requests_error(mock_requests_get: mock.Mock) -> None:
+def test_random_page_raises_click_exception_on_requests_error(
+    mock_requests_get: mock.Mock,
+) -> None:
     mock_requests_get.side_effect = requests.RequestException
     with pytest.raises(click.ClickException):
         wikipedia.random_page()

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -25,3 +25,9 @@ def test_random_page_uses_given_language(mock_requests_get: mock.Mock) -> None:
 def test_random_page_returns_page(mock_requests_get: mock.Mock) -> None:
     page = wikipedia.random_page()
     assert isinstance(page, wikipedia.Page)
+
+
+def test_random_page_handles_validation_errors(mock_requests_get: mock.Mock) -> None:
+    mock_requests_get.return_value.__enter__.return_value.json.return_value = None
+    with pytest.raises(click.ClickException):
+        wikipedia.random_page()

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -20,3 +20,8 @@ def test_random_page_uses_given_language(mock_requests_get: mock.Mock) -> None:
     wikipedia.random_page(language=language)
     url = wikipedia.get_api_url_for(language=language)
     mock_requests_get.assert_called_once_with(url, timeout=mock.ANY)
+
+
+def test_random_page_returns_page(mock_requests_get: mock.Mock) -> None:
+    page = wikipedia.random_page()
+    assert isinstance(page, wikipedia.Page)

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -7,13 +7,13 @@ import requests
 from hypermodern_python import wikipedia
 
 
-def test_random_page_raises_click_exception_on_requests_error(mock_requests_get):
+def test_random_page_raises_click_exception_on_requests_error(mock_requests_get: mock.Mock) -> None:
     mock_requests_get.side_effect = requests.RequestException
     with pytest.raises(click.ClickException):
         wikipedia.random_page()
 
 
-def test_random_page_uses_given_language(mock_requests_get):
+def test_random_page_uses_given_language(mock_requests_get: mock.Mock) -> None:
     language = "de"
     wikipedia.random_page(language=language)
     url = wikipedia.get_api_url_for(language=language)

--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -31,3 +31,10 @@ def test_random_page_handles_validation_errors(mock_requests_get: mock.Mock) -> 
     mock_requests_get.return_value.__enter__.return_value.json.return_value = None
     with pytest.raises(click.ClickException):
         wikipedia.random_page()
+
+
+# XXX: For demonstration purposes.
+# def test_trigger_typeguard(mock_requests_get):
+#     import json
+#     data = json.loads('{ "language": 1 }')
+#     wikipedia.random_page(language=data["language"])


### PR DESCRIPTION
# Why Are We Doing This

This is the fourth chapter of the Hypermodern Python Project series of articles which covers, mainly, type hints.

# Test Plan

1. `nox` - run the default quality checks.
2. `nox -s black` - run the additional style checker and verify no conflicts with the `flake8-black` package that ran with the `lint` session.
3. Uncomment the `test_trigger_typeguard` test in `test_wikipedia.py` and run `nox -s typeguard` and verify an error is raised.
