### PR TITLE
Fix RTFD Config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
   configuration: docs/conf.py
@@ -13,4 +13,3 @@ formats: all
 python:
   install:
     - requirements: docs/requirements.txt
-    - path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
 
 formats: all
 
 python:
-  version: 3.11
   install:
     - requirements: docs/requirements.txt
     - path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ priority = "explicit"
 
 [tool.poetry]
 name = "hypermodern-guyhoozdis"
-version = "0.6.8"
+version = "0.6.9"
 description = "A template package based on The Hypermodern Project"
 authors = ["Guy Hoozdis <GuyHoozdis@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Why Are We Doing This?

After merging #9, the [Read the Docs](https://hypermodern-guyhoozdis.rtfd.io) were raising errors trying to build the docs (see #10).


# Test Plan

1. The automated test suite passes (run manually if needed).
1. Verify the documentation hosted on [Read the Docs](https://hypermodern-guyhoozdis.rtfd.io) builds successfully.